### PR TITLE
Removed application context path from GuiceFilter url mapping

### DIFF
--- a/src/main/java/com/hubspot/dropwizard/guicier/GuiceBundle.java
+++ b/src/main/java/com/hubspot/dropwizard/guicier/GuiceBundle.java
@@ -105,7 +105,7 @@ public class GuiceBundle<T extends Configuration> implements ConfiguredBundle<T>
 
     dropwizardModule.register(environment, injector);
 
-    environment.servlets().addFilter("Guice Filter", GuiceFilter.class).addMappingForUrlPatterns(null, false, environment.getApplicationContext().getContextPath() + "*");
+    environment.servlets().addFilter("Guice Filter", GuiceFilter.class).addMappingForUrlPatterns(null, false, "/*");
     environment.servlets().addServletListeners(new GuiceServletContextListener() {
 
       @Override


### PR DESCRIPTION
Based on discussion [https://github.com/dropwizard/dropwizard/issues/1694](https://github.com/dropwizard/dropwizard/issues/1694) and Servlet Spec JSR-000315 Java Servlet 3.0 Final Release (Chapter 12, “Mapping Requests to Servlets”):

> The path used for mapping to a servlet is the request URL from the request object
**minus the context path and the path parameters**.

 Seems the url mapping for GuiceFilter shouldn't contain the application context path.