### PR TITLE
Use jdk 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
     </developer>
   </developers>
 
+  <properties>
+    <project.build.targetJdk>1.8</project.build.targetJdk>
+  </properties>
+
   <dependencies>
     <!-- Put this dep first so the ServiceLoader returns its classes first -->
     <dependency>


### PR DESCRIPTION
If I understand things correctly, Dropwizard 1.0 is [on Java 8](https://github.com/dropwizard/dropwizard/blob/release/1.0.x/pom.xml#L456-L457), so I think this should be a safe change for people using this library (though maybe I'm wrong).

@jhaber 