### PR TITLE
Put HK2 mappings in the main injector

### DIFF
--- a/src/test/java/com/hubspot/dropwizard/guicier/GuiceBundleTest.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/GuiceBundleTest.java
@@ -11,7 +11,6 @@ import javax.servlet.ServletException;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -59,13 +58,11 @@ public class GuiceBundleTest {
 
     @Test
     public void createsInjectorWhenInit() throws ServletException {
-        //then
         Injector injector = guiceBundle.getInjector();
         assertThat(injector).isNotNull();
     }
 
     @Test
-    @Ignore
     public void serviceLocatorIsAvaliable () throws ServletException {
         ServiceLocator serviceLocator = guiceBundle.getInjector().getInstance(ServiceLocator.class);
         assertThat(serviceLocator).isNotNull();


### PR DESCRIPTION
This makes it so that things bound by `JerseyGuiceModule` (`ServiceLocator`, `UriInfo`, etc.) are accessible within the application. In order to do this, I need to guess the name of the application's service locator, which I did via reflection. 

This will break if the same `GuiceBundle` a guice bundle is reused for multiple services, which seems reasonable to me. It is also the case that as this is written, only the main `ServiceLocator` will have our application's Guice modules installed. This seems fine, but I could change that if we think that that'd be safer.

@jhaber 