### PR TITLE
Don't log when Guice isn't in PRODUCTION mode

### DIFF
--- a/src/main/java/com/hubspot/dropwizard/guicier/GuiceBundle.java
+++ b/src/main/java/com/hubspot/dropwizard/guicier/GuiceBundle.java
@@ -157,9 +157,6 @@ public class GuiceBundle<T extends Configuration> implements ConfiguredBundle<T>
 
     public final Builder<U> stage(final Stage guiceStage) {
       checkNotNull(guiceStage, "guiceStage is null");
-      if (guiceStage != Stage.PRODUCTION) {
-        LOG.warn("Guice should only ever run in PRODUCTION mode except for testing!");
-      }
       this.guiceStage = guiceStage;
       return this;
     }


### PR DESCRIPTION
This logging was putting invalid and potentially confusing messages into our console. Removing it altogether is the easiest option, though adding a method like `stageNoWarn` is also an option.

@jhaber 
cc @mjball 