### PR TITLE
Upgrade versions for 1.3.5 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
       </dependency>
+      <!-- Redefined here in order to drop the snakeyaml exclusion -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>15.16</version>
+    <version>25.1</version>
   </parent>
 
   <groupId>com.hubspot.dropwizard</groupId>
   <artifactId>dropwizard-guicier</artifactId>
-  <version>1.0.9.2-SNAPSHOT</version>
+  <version>1.3.5.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@github.com:HubSpot/dropwizard-guicier.git</connection>
@@ -29,8 +29,43 @@
   </developers>
 
   <properties>
-    <project.build.targetJdk>1.8</project.build.targetJdk>
+    <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
+
+    <dep.assertj.version>3.9.1</dep.assertj.version>
+    <dep.classmate.version>1.3.1</dep.classmate.version>
+    <dep.commons-lang3.version>3.7</dep.commons-lang3.version>
+    <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>
+    <dep.guava.version>24.0-jre</dep.guava.version>
+    <dep.hibernate-validator.version>5.4.2.Final</dep.hibernate-validator.version>
+    <dep.hk2.version>2.5.0-b32</dep.hk2.version>
+    <dep.httpclient.version>4.5.5</dep.httpclient.version>
+    <dep.httpcore.version>4.4.9</dep.httpcore.version>
+    <dep.jackson.version>2.9.6</dep.jackson.version>
+    <dep.jackson-databind.version>2.9.6</dep.jackson-databind.version>
+    <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
+    <dep.jersey2.version>2.25.1</dep.jersey2.version>
+    <dep.jetty.version>9.4.11.v20180605</dep.jetty.version>
+    <dep.joda.version>2.9.9</dep.joda.version>
+    <dep.logback.version>1.2.3</dep.logback.version>
+    <dep.objenesis.version>2.6</dep.objenesis.version>
+    <dep.slf4j.version>1.7.25</dep.slf4j.version>
+    <dropwizard.version>1.3.5</dropwizard.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${dep.jackson.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Put this dep first so the ServiceLoader returns its classes first -->


### PR DESCRIPTION
I did some light testing and this appears to work fine with dropwizard 1.3.5 + jersey 2.25.1 + jackson 2.9.6 + hk2 2.5.0-b32 + guava 24.0-jre