### PR TITLE
Use ProvisionListener instead of InjectionListener for Dropwizard objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 target
+
+# IntelliJ
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/src/main/java/com/hubspot/dropwizard/guicier/DropwizardModule.java
+++ b/src/main/java/com/hubspot/dropwizard/guicier/DropwizardModule.java
@@ -5,11 +5,8 @@ import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.Matchers;
-import com.google.inject.spi.InjectionListener;
-import com.google.inject.spi.TypeEncounter;
-import com.google.inject.spi.TypeListener;
+import com.google.inject.spi.ProvisionListener;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import io.dropwizard.servlets.tasks.Task;
@@ -34,30 +31,26 @@ public class DropwizardModule implements Module {
 
   @Override
   public void configure(final Binder binder) {
-    binder.bindListener(Matchers.any(), new TypeListener() {
+    binder.bindListener(Matchers.any(), new ProvisionListener() {
       @Override
-      public <T> void hear(TypeLiteral<T> type, TypeEncounter<T> encounter) {
-        encounter.register(new InjectionListener<T>() {
+      public <T> void onProvision(ProvisionInvocation<T> provision) {
+        Object obj = provision.provision();
 
-          @Override
-          public void afterInjection(T obj) {
-            if (obj instanceof Managed) {
-              handle((Managed) obj);
-            }
+        if (obj instanceof Managed) {
+          handle((Managed) obj);
+        }
 
-            if (obj instanceof Task) {
-              handle((Task) obj);
-            }
+        if (obj instanceof Task) {
+          handle((Task) obj);
+        }
 
-            if (obj instanceof HealthCheck) {
-              handle((HealthCheck) obj);
-            }
+        if (obj instanceof HealthCheck) {
+          handle((HealthCheck) obj);
+        }
 
-            if (obj instanceof ServerLifecycleListener) {
-              handle((ServerLifecycleListener) obj);
-            }
-          }
-        });
+        if (obj instanceof ServerLifecycleListener) {
+          handle((ServerLifecycleListener) obj);
+        }
       }
     });
   }

--- a/src/test/java/com/hubspot/dropwizard/guicier/GuiceBundleTest.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/GuiceBundleTest.java
@@ -8,6 +8,11 @@ import java.util.function.Function;
 
 import javax.servlet.ServletException;
 
+import com.hubspot.dropwizard.guicier.objects.ProvidedHealthCheck;
+import com.hubspot.dropwizard.guicier.objects.ProvidedManaged;
+import com.hubspot.dropwizard.guicier.objects.ProvidedProvider;
+import com.hubspot.dropwizard.guicier.objects.ProvidedServerLifecycleListener;
+import com.hubspot.dropwizard.guicier.objects.ProvidedTask;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.After;
 import org.junit.Before;
@@ -112,5 +117,45 @@ public class GuiceBundleTest {
     public void itAddsBoundResource() {
         Set<Class<?>> resourceClasses = environment.jersey().getResourceConfig().getClasses();
         assertThat(resourceClasses).containsOnlyOnce(ExplicitResource.class);
+    }
+
+    @Test
+    public void itAddsProvidedManaged() {
+        ProvidedManaged providedManaged = guiceBundle.getInjector().getInstance(ProvidedManaged.class);
+        assertThat(environment.lifecycle().getManagedObjects())
+            .extracting("managed")
+            .containsOnlyOnce(providedManaged);
+    }
+
+    @Test
+    public void itAddsProvidedTask() {
+        ProvidedTask providedTask = guiceBundle.getInjector().getInstance(ProvidedTask.class);
+        assertThat(environment.admin())
+            .extracting("tasks")
+            .flatExtracting("tasks")
+            .containsOnlyOnce(providedTask);
+    }
+
+    @Test
+    public void itAddsProvidedHealthCheck() {
+        assertThat(environment.healthChecks().getNames())
+            .containsOnlyOnce(ProvidedHealthCheck.class.getSimpleName());
+    }
+
+    @Test
+    public void itAddsProvidedServerLifecycleListener() {
+        ProvidedServerLifecycleListener providedServerLifecycleListener =
+            guiceBundle.getInjector().getInstance(ProvidedServerLifecycleListener.class);
+        assertThat(environment.lifecycle())
+            .extracting(Function.identity())
+            .flatExtracting("lifecycleListeners")
+            .extracting("listener")
+            .containsOnlyOnce(providedServerLifecycleListener);
+    }
+
+    @Test
+    public void itAddsProvidedProvider() {
+        Set<Class<?>> components = environment.jersey().getResourceConfig().getClasses();
+        assertThat(components).containsOnlyOnce(ProvidedProvider.class);
     }
 }

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedHealthCheck.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedHealthCheck.java
@@ -1,0 +1,11 @@
+package com.hubspot.dropwizard.guicier.objects;
+
+import com.codahale.metrics.health.HealthCheck;
+
+public class ProvidedHealthCheck extends HealthCheck {
+
+    @Override
+    protected Result check() {
+        return Result.healthy();
+    }
+}

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedManaged.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedManaged.java
@@ -1,0 +1,15 @@
+package com.hubspot.dropwizard.guicier.objects;
+
+import io.dropwizard.lifecycle.Managed;
+
+public class ProvidedManaged implements Managed {
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedProvider.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedProvider.java
@@ -1,0 +1,7 @@
+package com.hubspot.dropwizard.guicier.objects;
+
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ProvidedProvider {
+}

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedServerLifecycleListener.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedServerLifecycleListener.java
@@ -1,0 +1,12 @@
+package com.hubspot.dropwizard.guicier.objects;
+
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import org.eclipse.jetty.server.Server;
+
+public class ProvidedServerLifecycleListener implements ServerLifecycleListener {
+
+  @Override
+  public void serverStarted(Server server) {
+
+  }
+}

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedTask.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/ProvidedTask.java
@@ -1,0 +1,18 @@
+package com.hubspot.dropwizard.guicier.objects;
+
+import java.io.PrintWriter;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+public class ProvidedTask extends Task {
+
+    public ProvidedTask(String name) {
+        super(name);
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> immutableMultimap, PrintWriter printWriter) {
+
+    }
+}

--- a/src/test/java/com/hubspot/dropwizard/guicier/objects/TestModule.java
+++ b/src/test/java/com/hubspot/dropwizard/guicier/objects/TestModule.java
@@ -1,13 +1,18 @@
 package com.hubspot.dropwizard.guicier.objects;
 
+import javax.inject.Singleton;
+
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
 public class TestModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(ExplicitDAO.class);
-        bindConstant().annotatedWith(Names.named("TestTaskName")).to("test task");
+        bindConstant().annotatedWith(Names.named("TestTaskName")).to("injected task");
+        bindConstant().annotatedWith(Names.named("ProvidedTaskName")).to("provided task");
 
         bind(InjectedManaged.class).asEagerSingleton();
         bind(InjectedTask.class).asEagerSingleton();
@@ -18,6 +23,35 @@ public class TestModule extends AbstractModule {
 
         bind(ExplicitResource.class);
         bind(JerseyContextResource.class);
+    }
+
+    @Provides
+    @Singleton
+    public ProvidedManaged provideManaged() {
+        return new ProvidedManaged();
+    }
+
+    @Provides
+    @Singleton
+    public ProvidedTask provideTask(@Named("ProvidedTaskName") String name) {
+        return new ProvidedTask(name);
+    }
+
+    @Provides
+    @Singleton
+    public ProvidedHealthCheck provideHealthCheck() {
+        return new ProvidedHealthCheck();
+    }
+
+    @Provides
+    @Singleton
+    public ProvidedServerLifecycleListener provideServerLifecycleListener() {
+        return new ProvidedServerLifecycleListener();
+    }
+
+    @Provides
+    public ProvidedProvider provideProvider() {
+        return new ProvidedProvider();
     }
 }
 


### PR DESCRIPTION
Ran into this problem trying to wire up a third party health check which is not `@Inject`able. I wired up the health check with a `@Provides @Singleton` method, but the health check was not registered like I expected.

`DropwizardModule` is listening for injections via `InjectionListener`, which is only notified when an `@Inject` object is injected. It is not notified when an object is obtained through a `@Provides` module method. See google/guice#565

This PR switches from `InjectionListener` to `ProvisionListener`, which is notified for both `@Inject` and `@Provides` objects.