### PR TITLE
Upgrade to latest basepom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ cache:
     - $HOME/.m2
 
 jdk:
-  - oraclejdk8
-
-before_install:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip
-  - unzip -qq apache-maven-3.5.4-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.5.4
-  - export PATH=$M2_HOME/bin:$PATH
+  - openjdk8
+  - openjdk11
 
 script: mvn -B clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.1</version>
+    <version>25.5</version>
   </parent>
 
   <groupId>com.hubspot.dropwizard</groupId>
@@ -32,23 +32,12 @@
     <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
 
     <dep.assertj.version>3.9.1</dep.assertj.version>
-    <dep.classmate.version>1.3.1</dep.classmate.version>
-    <dep.commons-lang3.version>3.7</dep.commons-lang3.version>
     <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>
-    <dep.guava.version>24.0-jre</dep.guava.version>
-    <dep.hibernate-validator.version>5.4.2.Final</dep.hibernate-validator.version>
     <dep.hk2.version>2.5.0-b32</dep.hk2.version>
-    <dep.httpclient.version>4.5.5</dep.httpclient.version>
-    <dep.httpcore.version>4.4.9</dep.httpcore.version>
-    <dep.jackson.version>2.9.6</dep.jackson.version>
-    <dep.jackson-databind.version>2.9.6</dep.jackson-databind.version>
-    <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
+    <dep.jackson.version>2.9.9</dep.jackson.version>
+    <dep.jackson-databind.version>2.9.9.3</dep.jackson-databind.version>
     <dep.jersey2.version>2.25.1</dep.jersey2.version>
-    <dep.jetty.version>9.4.11.v20180605</dep.jetty.version>
-    <dep.joda.version>2.9.9</dep.joda.version>
-    <dep.logback.version>1.2.3</dep.logback.version>
-    <dep.objenesis.version>2.6</dep.objenesis.version>
-    <dep.slf4j.version>1.7.25</dep.slf4j.version>
+    <dep.jetty.version>9.4.19.v20190610</dep.jetty.version>
     <dropwizard.version>1.3.5</dropwizard.version>
   </properties>
 
@@ -58,12 +47,6 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
-      </dependency>
-      <!-- Redefined here in order to drop the snakeyaml exclusion -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${dep.jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
A lot of these dependency overrides are no longer necessary with basepom 25.5